### PR TITLE
Add DiceRoller Matermost plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "Unofficial/mattermost-plugin-autolink"]
 	path = Unofficial/mattermost-plugin-autolink
 	url = https://github.com/mattermost/mattermost-plugin-autolink.git
+[submodule "Unofficial/mattermost-plugin-dice-roller"]
+	path = Unofficial/mattermost-plugin-dice-roller
+	url = https://github.com/moussetc/mattermost-plugin-dice-roller.git


### PR DESCRIPTION
The dice roller plugin adds a command to get dice rolling results as public messages.