### PR TITLE
Add mattermost-plugin-jitsi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "Unofficial/mattermost-plugin-autolink"]
 	path = Unofficial/mattermost-plugin-autolink
 	url = https://github.com/mattermost/mattermost-plugin-autolink.git
+[submodule "Unofficial/mattermost-plugin-jitsi"]
+	path = Unofficial/mattermost-plugin-jitsi
+	url = https://github.com/seansackowitz/mattermost-plugin-jitsi


### PR DESCRIPTION
Adds the ability to start Jitsi meetings from Mattermost on a self-hosted or off-site Jitsi-Meet instance.