### PR TITLE
switch url for kopano plugins to github clones for better navigation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,10 +15,10 @@
 	url = https://github.com/mattermost/mattermost-plugin-memes
 [submodule "Unofficial/mattermost-plugin-kopanowebmeetings"]
 	path = Unofficial/mattermost-plugin-kopanowebmeetings
-	url = https://stash.kopano.io/scm/km/mattermost-plugin-kopanowebmeetings.git
+	url = https://github.com/Kopano-dev/mattermost-plugin-kopanowebmeetings.git
 [submodule "Unofficial/mattermost-plugin-notifymatters"]
 	path = Unofficial/mattermost-plugin-notifymatters
-	url = https://fbartels@stash.kopano.io/scm/km/mattermost-plugin-notifymatters.git
+	url = https://github.com/Kopano-dev/mattermost-plugin-notifymatters.git
 [submodule "Unofficial/mattermost-plugin-autolink"]
 	path = Unofficial/mattermost-plugin-autolink
 	url = https://github.com/mattermost/mattermost-plugin-autolink.git


### PR DESCRIPTION
Hi, 

I've noticed that the git repo hosted on our local stash do not visually integrate in the github web ui. I have therefore replaced them with with their github mirrors.