### PR TITLE
add plugin analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Certified by the Mattermost team, and tested prior to each Mattermost server rel
 
 #### Unofficial
 Non-production plugins built by Mattermost staff and community.
+- [mattermost-plugin-analytics](https://github.com/manland/mattermost-plugin-analytics)
 - [mattermost-plugin-antivirus](https://github.com/mattermost/mattermost-plugin-antivirus)
 - [mattermost-plugin-autolink](https://github.com/mattermost/mattermost-plugin-autolink)
 - [mattermost-plugin-autotranslate](https://github.com/mattermost/mattermost-plugin-autotranslate)


### PR DESCRIPTION
Hi,

This is my plugin analytics. 

When installed and configured, it send a post with top 3 speakers (most active user) and top 3 channels where to be (most conversations take place).

![selection_199](https://user-images.githubusercontent.com/1492516/53529412-cd25a500-3aec-11e9-9154-11a603c1503f.png)


It's not perfect, and @hanzei have already do a good job to help me clean it. But I need feedback, about it.

I have lots of [issues](https://github.com/manland/mattermost-plugin-analytics/issues) but I need you to prioritize them ;)

If someone want to give it a try, just open an issue with your feedback.

Thanks